### PR TITLE
[DM-33787] Make husky a normal dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "husky": "^7.0.4",
         "next": "latest",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -17,7 +18,6 @@
         "eslint": "8.4.1",
         "eslint-config-next": "12.0.7",
         "eslint-config-prettier": "^8.3.0",
-        "husky": "^7.0.4",
         "lint-staged": "^12.1.2",
         "prettier": "^2.5.1"
       }
@@ -2068,7 +2068,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
       "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -5580,8 +5579,7 @@
     "husky": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ=="
     },
     "ignore": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "husky": "^7.0.4",
     "next": "latest",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -22,7 +23,6 @@
     "eslint": "8.4.1",
     "eslint-config-next": "12.0.7",
     "eslint-config-prettier": "^8.3.0",
-    "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
     "prettier": "^2.5.1"
   },


### PR DESCRIPTION
By making it a normal dependency hopefully it'll be there for making
the production install, since npm install --production was failing
with husky command not found.