### PR TITLE
[DM-34317] Use /etc/sherlock for environments.json

### DIFF
--- a/lib/environments.js
+++ b/lib/environments.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
-let envData = require("../environments.json");
+
+let envData = require("/etc/sherlock/environments.json");
 
 export function getEnvironments() {
   return envData;

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: environments
-              mountPath: "/app/environments.json"
+              mountPath: "/etc/sherlock/environments.json"
               subPath: "environments.json"
             - name: tmp
               mountPath: "/tmp"

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/sherlock-frontend
-    newTag: 0.0.17
+    newTag: 0.0.18
 
 resources:
   - deployment.yaml


### PR DESCRIPTION
So I've tried to use an environment variable for this, but NPM
really doesn't seem to like it.  So instead, let's just use a
path in /etc and mount it there.