### PR TITLE
[DM-34317] Use readfilesync as opposed to require

### DIFF
--- a/lib/environments.js
+++ b/lib/environments.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 
-let envData = require("/etc/sherlock/environments.json");
+let rawdata = fs.readFileSync("/etc/sherlock/environments.json");
+let envData = JSON.parse(rawdata);
 
 export function getEnvironments() {
   return envData;


### PR DESCRIPTION
I think require is getting in the way with the webpack and other
dependency things.  It does seem to work, but it also seemed to
somehow cache the keys and not use the actual keys when the file
changes.  Hopefully this will work.